### PR TITLE
Update I - RemoteEvents no longer needed in setup, unneeded coroutines removed

### DIFF
--- a/src/ClientScript.lua
+++ b/src/ClientScript.lua
@@ -30,12 +30,6 @@ local function executeTweenInstanceFull(target, time, style, dir, repCount, rev,
 	tween:Play()
 end
 
-astraTween.FireClientTweenModel.OnClientEvent:Connect(function(model, time, style, dir, endCF)
-	coroutine.wrap(executeTweenModel)(model, time, style, dir, endCF)
-end)
-astraTween.FireClientTweenInstance.OnClientEvent:Connect(function(target, time, style, dir, goalTable)
-	coroutine.wrap(executeTweenInstance)(target, time, style, dir, goalTable)
-end)
-astraTween.FireClientTweenInstanceFull.OnClientEvent:Connect(function(target, time, style, direction, repCount, reverses, delayTime, goalTable)
-	coroutine.wrap(executeTweenInstanceFull)(target, time, style, direction, repCount, reverses, delayTime, goalTable)
-end)
+astraTween:getRemote("FireClientTweenModel").OnClientEvent:Connect(executeTweenModel)
+astraTween:getRemote("FireClientTweenInstance").OnClientEvent:Connect(executeTweenInstance)
+astraTween:getRemote("FireClientTweenInstanceFull").OnClientEvent:Connect(executeTweenInstanceFull)

--- a/src/ClientScript.lua
+++ b/src/ClientScript.lua
@@ -30,6 +30,16 @@ local function executeTweenInstanceFull(target, time, style, dir, repCount, rev,
 	tween:Play()
 end
 
-astraTween:getRemote("FireClientTweenModel").OnClientEvent:Connect(executeTweenModel)
-astraTween:getRemote("FireClientTweenInstance").OnClientEvent:Connect(executeTweenInstance)
-astraTween:getRemote("FireClientTweenInstanceFull").OnClientEvent:Connect(executeTweenInstanceFull)
+-- Name to Function dict for remoteevent names (used in below function)
+local NtF = {
+	["FireClientTweenModel"] = executeTweenModel,
+	["FireClientTweenInstance"] = executeTweenInstance,
+	["FireClientTweenInstanceFull"] = executeTweenInstanceFull,
+}
+
+-- Block to connect RemoteEvents as they are made, removes the need for pre-making remote events
+astraTween.ChildAdded:Connect(function(child)
+	if child.ClassName == "RemoteEvent" and NtF[child.Name] then
+		require(astraTween):getRemote(child.Name).OnClientEvent:Connect(NtF[child.Name])
+	end	
+end)

--- a/src/ServerModule.lua
+++ b/src/ServerModule.lua
@@ -27,7 +27,7 @@ local _fireCTIrem, _fireCTIFrem, _fireCTMrem -- fireClientTweenInstance, fireCli
 
 local remotes = {["FireClientTweenInstance"] = _fireCTIrem, ["FireClientTweenInstanceFull"] = _fireCTIFrem, ["FireClientTweenModel"] = _fireCTMrem}
 
-local function getRemote(name):RemoteEvent
+function AstraTween:getRemote(name):RemoteEvent
   if remotes[name] then
     return remotes[name]
   else
@@ -118,7 +118,7 @@ function AstraTween:TweenModel(model:Model, time:number, style:Enum.EasingStyle,
 	local endCF = AstraTween:checkGoalCFrame(goalPosition)
                         
 	if model.PrimaryPart then
-		getRemote("FireClientTweenModel"):FireAllClients(model, time, style, dir, endCF)
+		AstraTween:getRemote("FireClientTweenModel"):FireAllClients(model, time, style, dir, endCF)
 		task.delay(time, function()
 		        model:PivotTo(endCF)	
                 end)
@@ -135,7 +135,7 @@ function AstraTween:TweenInstance(target:Instance, time:number, style:Enum.Easin
 	goalTable = AstraTween:CheckGoalTable(goalTable)
 
 	if target then
-		getRemote("FireClientTweenInstance"):FireAllClients(target, time, style, direction, goalTable)
+		AstraTween:getRemote("FireClientTweenInstance"):FireAllClients(target, time, style, direction, goalTable)
 		task.delay(time, function()
 		        for i, v in pairs(goalTable) do
 			        target[i] = v
@@ -151,7 +151,7 @@ function AstraTween:TweenInstanceFull(target:Instance, time:number, style:Enum.E
 	goalTable = AstraTween:CheckGoalTable(goalTable)
 	
         if target then
-		getRemote("FireClientTweenInstanceFull"):FireAllClients(target, time, style, direction, repCount, reverses, delayTime, goalTable)
+		AstraTween:getRemote("FireClientTweenInstanceFull"):FireAllClients(target, time, style, direction, repCount, reverses, delayTime, goalTable)
 		task.delay(time, function()
 		        for i, v in pairs(goalTable) do
 		        	target[i] = v

--- a/src/ServerModule.lua
+++ b/src/ServerModule.lua
@@ -1,48 +1,41 @@
 --[[
-{EXPERIMENTAL BRANCH CHANGES}
-* Replacing wait() with task.wait() (idk why i didn't do this before)
-* Attempting to remove the need for manual RemoteEvent setup
+DOCS
 
-- removed any functions used in TweenUI (there's no need for it)
+AstraTween:TweenModel(model:Model, time:number, style:Enum.EasingStyle, direction:Enum.EasingDirection, goal:CFrame|Vector3|BasePart|UnionOperation)
+   Tweens a model using the PrimaryPart as a pivot. PrimaryPart must be set for this to work.
 
+TweenInstance(target:Instance, time:number, style:Enum.EasingStyle, direction:Enum.EasingDirection, goalTable:{Property = goalValue, ...})
+   Tweens an instance. goalTable follows same structure as TweenService:Create().
 
--- main branch notes ---------------------------------------------------------------------------------------
-IMPORTANT!!!!!! THE MODULE WILL NOT WORK IF YOU DO NOT FOLLOW THESE STEPS
-You need to add 3 RemoteEvents as children of this modulescript. I would add
-an auto-setup if I knew how (would need a server script to do setup and that would complicate things :/)
-
-Name them the following:
-"FireClientTweenInstance"
-"FireClientTweenInstanceFull"
-"FireClientTweenModel"
-------------------------------------------------------------------------------------------------------------
+TweenInstanceFull(target:Instance, time:number, style:Enum.EasingStyle, direction:Enum.EasingDirection, repCount:number, reverses:boolean, delayTime:number, goalTable:{Property = goalValue, ...})
+   Tweens an instance. Used to access lesser used arguments. (repCount, reverses, delayTime)
+   Functionally identical to TweenService:Create(), goalTable uses same structure.
 
 ]]--
 
 -- MODULESCRIPT (Should be placed in ReplicatedStorage)
-local ts = game:GetService("TweenService")
 local AstraTween = {}
 
-local _fireCTIrem, _fireCTIFrem, _fireCTMrem -- fireClientTweenInstance, fireClientTweenInstanceFull, fireClientTweenModel (will be set later)
+local _fireCTIrem, _fireCTIFrem, _fireCTMrem = nil,nil,nil -- fireClientTweenInstance, fireClientTweenInstanceFull, fireClientTweenModel (will be set later)
 
 local remotes = {["FireClientTweenInstance"] = _fireCTIrem, ["FireClientTweenInstanceFull"] = _fireCTIFrem, ["FireClientTweenModel"] = _fireCTMrem}
 
 function AstraTween:getRemote(name):RemoteEvent
-  if remotes[name] then
-    return remotes[name]
-  else
-    local named = script:FindFirstChild(name)
-    if named then
-      remotes[name] = named
-      return named
-    end
+	if remotes[name] then
+		return remotes[name]
+	else
+		local named = script:FindFirstChild(name)
+		if named then
+			remotes[name] = named
+			return named
+		end
 
-    local newRemote = Instance.new("RemoteEvent")
-    newRemote.Name = name
-    newRemote.Parent = script
-    remotes[name] = newRemote
-    return newRemote
-  end
+		local newRemote = Instance.new("RemoteEvent")
+		newRemote.Name = name
+		newRemote.Parent = script
+		remotes[name] = newRemote
+		return newRemote
+	end
 end
 
 function AstraTween:checkStyle(input)
@@ -116,12 +109,12 @@ function AstraTween:TweenModel(model:Model, time:number, style:Enum.EasingStyle,
 	local style = AstraTween:checkStyle(style)
 	local dir = AstraTween:checkDir(direction)
 	local endCF = AstraTween:checkGoalCFrame(goalPosition)
-                        
+
 	if model.PrimaryPart then
 		AstraTween:getRemote("FireClientTweenModel"):FireAllClients(model, time, style, dir, endCF)
 		task.delay(time, function()
-		        model:PivotTo(endCF)	
-                end)
+			model:PivotTo(endCF)	
+		end)
 	else
 		warn("Model does not have a PrimaryPart!")
 		return
@@ -137,10 +130,10 @@ function AstraTween:TweenInstance(target:Instance, time:number, style:Enum.Easin
 	if target then
 		AstraTween:getRemote("FireClientTweenInstance"):FireAllClients(target, time, style, direction, goalTable)
 		task.delay(time, function()
-		        for i, v in pairs(goalTable) do
-			        target[i] = v
+			for i, v in pairs(goalTable) do
+				target[i] = v
 			end
-                end)
+		end)
 	end
 end
 
@@ -149,16 +142,15 @@ function AstraTween:TweenInstanceFull(target:Instance, time:number, style:Enum.E
 	style = AstraTween:checkStyle(style)
 	direction = AstraTween:checkDir(direction)
 	goalTable = AstraTween:CheckGoalTable(goalTable)
-	
-        if target then
+
+	if target then
 		AstraTween:getRemote("FireClientTweenInstanceFull"):FireAllClients(target, time, style, direction, repCount, reverses, delayTime, goalTable)
 		task.delay(time, function()
-		        for i, v in pairs(goalTable) do
-		        	target[i] = v
-		        end
-                end)
+			for i, v in pairs(goalTable) do
+				target[i] = v
+			end
+		end)
 	end
 end
 
 return AstraTween
-


### PR DESCRIPTION
This update (with the help of those in the Nuclear Engineering Corp. and Nova! Inc. Discords) removes the need to manually create RemoteEvents during setup and simplifies the code with the `task` library.

Full change log:
> You no longer need to create RemoteEvents by hand during setup (thanks Harry!)
> Server code now uses `task.delay` instead of `coroutine.wrap` to simplify code
> Server code now uses `task.wait` and not `wait`
> Remotes are now generated and connected dynamically when the function they relate to is called for the first time
> Removed functions related to legacy versions (back when :TweenUI was a thing)
> Removed the TweenService reference in the modulescript (idk why it was there in the first place)