### PR TITLE
Connect remotes already in datamodel

### DIFF
--- a/src/ClientScript.lua
+++ b/src/ClientScript.lua
@@ -37,9 +37,16 @@ local NtF = {
 	["FireClientTweenInstanceFull"] = executeTweenInstanceFull,
 }
 
--- Block to connect RemoteEvents as they are made, removes the need for pre-making remote events
-astraTween.ChildAdded:Connect(function(child)
+local function connectChild(child: Instance)
 	if child.ClassName == "RemoteEvent" and NtF[child.Name] then
 		require(astraTween):getRemote(child.Name).OnClientEvent:Connect(NtF[child.Name])
 	end	
-end)
+end
+
+-- Block to connect RemoteEvents as they are made, removes the need for pre-making remote events
+astraTween.ChildAdded:Connect(connectChild)
+
+for _, child in astraTween:GetChildren() do
+	task.defer(connectChild, child)
+end
+


### PR DESCRIPTION
This PR will connect remotes that are already created and in ReplicatedStorage. This should close #6.

Here's a demonstration of multiple instance tweens working with multiple players:
https://user-images.githubusercontent.com/44583181/232254080-a08024aa-175c-4eaa-97a6-cc9dff0bef52.mp4